### PR TITLE
Changing error output to provide more information

### DIFF
--- a/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
+++ b/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
@@ -1,4 +1,4 @@
-﻿<#PSScriptInfo
+<#PSScriptInfo
 
 .VERSION 2.2
 
@@ -817,7 +817,7 @@ If($Mode -eq "Import")
                 }
                 catch
                 {
-                    StandardError -Exception $($_.Exception.Message)
+                    StandardError -Exception $($_.ErrorDetails.Message)
                     exit 1
                 }
             }
@@ -840,7 +840,7 @@ If($Mode -eq "Import")
                 }
                 catch
                 {
-                    StandardError -Exception $($_.Exception.Message)
+                    StandardError -Exception $($_.ErrorDetails.Message)
                     exit 1
                 }
             }


### PR DESCRIPTION
When importing Blueprints containing errors the current error message results in 
'Response status code does not indicate success: 400 (Bad Request).'

Changing the output to '$_.ErrorDetails.Message' it returns a more helpful error for example:
{
  "error": {
    "code": "InvalidArtifact",
    "message": "This artifact is invalid. Error: 'Required property '$schema' not found in JSON. Path '', line 15, position 1.'"
  }
}

