### PR TITLE
new API version to support tags on RG artifacts

### DIFF
--- a/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
+++ b/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
@@ -332,7 +332,7 @@ else
     # Sometimes $myinvocation is null, it depends on the PS console host
     $CurrentDir = "."
 }
-$APIVersion = "?api-version=2017-11-11-preview"
+$APIVersion = "?api-version=2018-11-01-preview"
 #cd $CurrentDir
 
 # Determine what we are doing - export/import/report


### PR DESCRIPTION
The new API version 2018-11-01-preview supports tags on resource group artifacts in the main blueprint file. The old API version throws an error 500 when adding tags.