### PR TITLE
Update Manage-AzureRMBlueprint.ps1

### DIFF
--- a/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
+++ b/Scripts/Manage-AzureRMBlueprint/Manage-AzureRMBlueprint.ps1
@@ -759,7 +759,7 @@ If($Mode -eq "Export" -or $Mode -eq "Report")
 
                 Write-Host "Exporting Artifact($Kind): " -NoNewline -ForegroundColor Cyan
                 write-host "$Name.json" -ForegroundColor Yellow
-                $Artifact|ConvertTo-Json -Depth 50|Out-File "$ExportDir\$TargetBPName\$Name.json"
+                $Artifact|ConvertTo-Json -Depth 50 |  ForEach-Object { [System.Text.RegularExpressions.Regex]::Unescape($_) } | Out-File "$ExportDir\$TargetBPName\$Name.json"
             }
         }
         # Report logic for exporting a basic report of a Blueprint and Artifacts        


### PR DESCRIPTION
@JimGBritt  
Noticed when exporting the artifacts and they are being converted to json the " ' "  character isn't being escaped and showing up in the json files as seen below:
Ex. "[parameters(\u0027Owners\u0027)]"
Instead of "[parameters('Owners')]"